### PR TITLE
Fixed time and date in status bar

### DIFF
--- a/rose-pine-tmux.tmux
+++ b/rose-pine-tmux.tmux
@@ -51,7 +51,7 @@ set "status-style" "fg=$iris,bg=$base,bold"
 rosepine_time_format=$(get "@time_format" "%R")
 rosepine_date_format=$(get "@date_format" "%d/%m/%Y")
 
-datetime_block="#[fg=$gold,bg=$base] ${time_format} ${date_format}"
+datetime_block="#[fg=$gold,bg=$base] ${rosepine_time_format} ${rosepine_date_format}"
 host_block="#[fg=$iris,bg=$base] #h "
 set "status-right" "${datetime_block} ${host_block}"
 set "status-left" "#[fg=$iris,bg=$base] #S "


### PR DESCRIPTION
Time and date section was broken. Reason was the variable created to build new formats was incorrectly referenced.

https://github.com/mcanueste/rose-pine-tmux/blob/main/rose-pine-tmux.tmux#L51-L54

https://github.com/ryanleonbutler/dotfiles/blob/main/tmux/tmux.conf#L80
![Screenshot 2023-01-03 at 09 05 56](https://user-images.githubusercontent.com/32143470/210312875-716cd8e5-4215-4cea-ad3b-b8c55d943e30.png)
